### PR TITLE
Add virtual destructor to span class

### DIFF
--- a/src/geo/path.hpp
+++ b/src/geo/path.hpp
@@ -47,6 +47,8 @@ class Span{
         virtual double length2d()const = 0;
         /// return a point at parameter value 0 <= t <= 1.0
         virtual Point getPoint(double t) const = 0; // 0.0 to 1.0
+        /// avoid gcc 4.7.1 delete-non-virtual-dtor error
+        virtual ~Span();
 };
 
 /// Line Span


### PR DESCRIPTION
Without virtual destructor gcc 4.7.1 (on arch linux) raises delete-non-virtual-dtor error during compilation:

```
/tmp/packerbuild-1000/opencamlib-svn/opencamlib-svn/src/opencamlib/src/algo/adaptivewaterline.cpp: In member function ‘void ocl::AdaptiveWaterline::adaptive_sampling_run()’:
/tmp/packerbuild-1000/opencamlib-svn/opencamlib-svn/src/opencamlib/src/algo/adaptivewaterline.cpp:123:12: error: deleting object of abstract class type ‘ocl::Span’ which has non-virtual destructor will cause undefined behaviour [-Werror=delete-non-virtual-dtor]
```

I don't know if this is a proper fix and I have yet to use ocl but it allows me to build.
