### PR TITLE
build the ocl python module specifically for python2

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,7 +27,7 @@ endif(NOT BUILD_DOC)
 # figure out the gcc version
 INCLUDE(gcc_version.cmake)
 
-find_package (PythonLibs REQUIRED)
+find_package (PythonLibs 2 REQUIRED)
 include_directories(${PYTHON_INCLUDE_DIRS} )
 
 #


### PR DESCRIPTION
Without this commit, cmake will pick the highest available version number
of PythonLibs to build against.  On machines with both python2 and python3
dev packages installed, this would incorrectly try to build for python3.

With this commit, cmake will pick the highest available 2.x.y version
of PythonLibs, which is what we want.