### PR TITLE
Fix build under Unix platform with recent CMake

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -323,9 +323,9 @@ if (BUILD_PY_LIB)
   # 
   # this makes the lib name ocl.so and not libocl.so
   set_target_properties(ocl PROPERTIES PREFIX "") 
-  if (NOT APPLE)
+  if (WIN32)
     set_target_properties(ocl PROPERTIES VERSION ${MY_VERSION}) 
-  endif (NOT APPLE)   
+  endif (WIN32)
 
   install(
     TARGETS ocl

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -477,8 +477,6 @@ if (BUILD_DOC)
   endif(DOXYGEN_FOUND)
 endif (BUILD_DOC)
 
-include(${CMAKE_SOURCE_DIR}/deb/package_details.cmake)
-
 # "make spackage"
 add_custom_target(spackage 
   ${CMAKE_COMMAND} 


### PR DESCRIPTION
Two patches to be able to compile it under Unix platform (at least Debian-based one).

First remove version on library: that disturb debhelper and break packaging.
Second remove an include in CMakeFile.txt that do not exist.

Note: it could make sense to remove deb packaging using CMake as its not the right way to build it.