### PR TITLE
camvtk: use vtk6 api

### DIFF
--- a/src/lib/camvtk.py
+++ b/src/lib/camvtk.py
@@ -352,7 +352,7 @@ class Cone(CamvtkActor):
         transformFilter.Update()
         
         self.mapper = vtk.vtkPolyDataMapper()
-        self.mapper.SetInput(transformFilter.GetOutput())
+        self.mapper.SetInputData(transformFilter.GetOutput())
         
         
         #self.mapper = vtk.vtkPolyDataMapper()
@@ -372,7 +372,7 @@ class Sphere(CamvtkActor):
         self.src.SetPhiResolution(resolution)
 
         self.mapper = vtk.vtkPolyDataMapper()
-        self.mapper.SetInput(self.src.GetOutput())
+        self.mapper.SetInputData(self.src.GetOutput())
         self.SetMapper(self.mapper)
         self.SetColor(color)
 
@@ -387,7 +387,7 @@ class Cube(CamvtkActor):
         self.src.SetZLength(length)
         
         self.mapper = vtk.vtkPolyDataMapper()
-        self.mapper.SetInput(self.src.GetOutput())
+        self.mapper.SetInputData(self.src.GetOutput())
         self.SetMapper(self.mapper)
         self.SetColor(color)
 
@@ -418,7 +418,7 @@ class Cylinder(CamvtkActor):
         
         self.mapper = vtk.vtkPolyDataMapper()
         #self.mapper.SetInput(self.src.GetOutput())
-        self.mapper.SetInput( transformFilter.GetOutput() )
+        self.mapper.SetInputData( transformFilter.GetOutput() )
         self.SetMapper(self.mapper)
         self.SetColor(color)
 
@@ -431,7 +431,7 @@ class Line(CamvtkActor):
         self.src.SetPoint1(p1)
         self.src.SetPoint2(p2)
         self.mapper = vtk.vtkPolyDataMapper()
-        self.mapper.SetInput(self.src.GetOutput())
+        self.mapper.SetInputData(self.src.GetOutput())
         self.SetMapper(self.mapper)
         self.SetColor(color)
 
@@ -443,7 +443,7 @@ class Tube(CamvtkActor):
         self.src.SetPoint2(p2)
         
         self.tubefilter = vtk.vtkTubeFilter()
-        self.tubefilter.SetInput( self.src.GetOutput() )
+        self.tubefilter.SetInputData( self.src.GetOutput() )
         self.tubefilter.SetRadius( radius )
         self.tubefilter.SetNumberOfSides( 30 )
         self.tubefilter.Update()
@@ -481,7 +481,7 @@ class Circle(CamvtkActor):
         self.pdata.SetLines(lines)
         
         self.mapper = vtk.vtkPolyDataMapper()
-        self.mapper.SetInput(self.pdata)
+        self.mapper.SetInputData(self.pdata)
         self.SetMapper(self.mapper)
         self.SetColor(color)
         
@@ -502,13 +502,13 @@ class Tube(CamvtkActor):
         self.pdata.SetLines(lines)
 
         tubefilter=vtk.vtkTubeFilter()
-        tubefilter.SetInput(self.pdata)
+        tubefilter.SetInputData(self.pdata)
         tubefilter.SetRadius(radius)
         tubefilter.SetNumberOfSides(50)
         tubefilter.Update()
         
         self.mapper = vtk.vtkPolyDataMapper()
-        self.mapper.SetInput(tubefilter.GetOutput())
+        self.mapper.SetInputData(tubefilter.GetOutput())
         self.SetMapper(self.mapper)
         self.SetColor(color)
 
@@ -523,7 +523,7 @@ class Point(CamvtkActor):
         self.src.SetNumberOfPoints(1)
 
         self.mapper = vtk.vtkPolyDataMapper()
-        self.mapper.SetInput(self.src.GetOutput())
+        self.mapper.SetInputData(self.src.GetOutput())
         self.SetMapper(self.mapper)
         self.SetColor(color)
 
@@ -546,7 +546,7 @@ class Arrow(CamvtkActor):
         
 
         self.mapper = vtk.vtkPolyDataMapper()
-        self.mapper.SetInput( transformFilter.GetOutput() )
+        self.mapper.SetInputData( transformFilter.GetOutput() )
         self.SetMapper(self.mapper)
         self.SetColor(color)
 
@@ -622,7 +622,7 @@ class Axes(vtk.vtkActor):
         #self.src.SetCenter(center)
 
         self.mapper = vtk.vtkPolyDataMapper()
-        self.mapper.SetInput(self.src.GetOutput())
+        self.mapper.SetInputData(self.src.GetOutput())
         self.SetMapper(self.mapper)
 
         self.SetColor(color)
@@ -659,7 +659,7 @@ class Toroid(CamvtkActor):
         transformFilter.Update()
         
         self.mapper = vtk.vtkPolyDataMapper()
-        self.mapper.SetInput(transformFilter.GetOutput())
+        self.mapper.SetInputData(transformFilter.GetOutput())
         self.SetMapper(self.mapper)
         self.SetColor(color)    
 
@@ -714,7 +714,7 @@ class STLSurf(CamvtkActor):
             polydata.Update()
             self.src=polydata
             self.mapper = vtk.vtkPolyDataMapper()
-            self.mapper.SetInput(self.src)
+            self.mapper.SetInputData(self.src)
             self.SetMapper(self.mapper)
             
         else: # a filename was specified
@@ -722,7 +722,7 @@ class STLSurf(CamvtkActor):
             self.src.SetFileName(filename)
             self.src.Update()
             self.mapper = vtk.vtkPolyDataMapper()
-            self.mapper.SetInput(self.src.GetOutput())
+            self.mapper.SetInputData(self.src.GetOutput())
             self.SetMapper(self.mapper)
 
         self.SetColor(color)
@@ -758,7 +758,7 @@ class PointCloud(CamvtkActor):
         polydata.Update()
         self.src=polydata
         self.mapper = vtk.vtkPolyDataMapper()
-        self.mapper.SetInput(self.src)
+        self.mapper.SetInputData(self.src)
         self.SetMapper(self.mapper)
         #self.SetColor(color)
         
@@ -790,7 +790,7 @@ class CLPointCloud(CamvtkActor):
         polydata.Update()
         self.src=polydata
         self.mapper = vtk.vtkPolyDataMapper()
-        self.mapper.SetInput(self.src)
+        self.mapper.SetInputData(self.src)
         self.SetMapper(self.mapper)
         #self.SetColor(color)
 
@@ -801,7 +801,7 @@ class Plane(CamvtkActor):
         self.src = vtk.vtkPlaneSource()
         #self.src.SetCenter(center)
         self.mapper = vtk.vtkPolyDataMapper()
-        self.mapper.SetInput(self.src.GetOutput())
+        self.mapper.SetInputData(self.src.GetOutput())
         self.SetMapper(self.mapper)
 
         self.SetColor(color)


### PR DESCRIPTION
This commit updates camvtk to use the VTK6 API instead of the VTK5 API
it used before this commit.

VTK5 is present in Debian Jessie and earlier.

VTK6 is present in Debian Jessie and later.