### PR TITLE
More misc. typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ such as mills and lathes. From August 2018 OpenCAMLib is released under LGPL lic
 BUILDING and INSTALLING 
 -----------------------
 
-to clone, build and install install the ocl.so library and camvtk.py run the follwing::
+to clone, build and install install the ocl.so library and camvtk.py run the following::
 
  $ git clone git://github.com/aewallin/opencamlib.git
  $ cd opencamlib

--- a/src/algo/simple_weave.cpp
+++ b/src/algo/simple_weave.cpp
@@ -179,9 +179,9 @@ void SimpleWeave::add_int_vertex(  const Point& v_position, // position of new v
     Edge ye_lu_next, ye_lu_prev ;
     Edge ye_ul_next, ye_ul_prev ;
     Edge ye_lu, ye_ul;
-                 
-    bool y_lu_edge = g.has_edge(y_l,y_u); // flag indicating existing y_l - y_u edge 
-    // the case where y_l and y_u are alread already connected.
+
+    bool y_lu_edge = g.has_edge(y_l,y_u); // flag indicating existing y_l - y_u edge
+    // the case where y_l and y_u are already connected.
 
     if ( y_lu_edge ) {
         assert( g.has_edge( y_u, y_l ) ); // twin must also exist

--- a/src/attic/ocode.cpp
+++ b/src/attic/ocode.cpp
@@ -276,7 +276,7 @@ bool Ocode::operator==(const Ocode &o){
 
 
 /*
- * /// return correspinding number
+ * /// return corresponding number
 unsigned long Ocode::number() const {
     unsigned long n=0;
     for (int m=0;m<depth;m++) {

--- a/src/cutters/compositecutter.hpp
+++ b/src/cutters/compositecutter.hpp
@@ -49,7 +49,7 @@ class CompositeCutter : public MillingCutter {
         
         MillingCutter* offsetCutter(double d) const;
         
-        /// CompositeCutter can not use the base-class facetDrop, intstead we here
+        /// CompositeCutter can not use the base-class facetDrop, instead we here
         /// call facetDrop() on each cutter in turn, and pick the valid CC/CL point 
         /// as the result for the CompositeCutter
         bool facetDrop(CLPoint &cl, const Triangle &t) const;

--- a/src/geo/point.hpp
+++ b/src/geo/point.hpp
@@ -100,7 +100,7 @@ class Point {
         /// returns true if point is right of line through p1 and p2 (works in the XY-plane)
         bool isRight(const Point &p1, const Point &p2) const;
          
-        /// retruns true if Point *this is inside Triangle t 
+        /// returns true if Point *this is inside Triangle t 
         bool isInside(const Triangle &t) const; 
         /// return true if Point within line segment p1-p2
         bool isInside(const Point& p1, const Point& p2) const;


### PR DESCRIPTION
Found via `codespell -q 3 -I ../opencamlib-word-whitelist.txt` whereby whitelist consisted of:  
```
childs
tim
whe
yau
```