### PR TITLE
fix python3 syntax error

### DIFF
--- a/src/lib/STLTools.py
+++ b/src/lib/STLTools.py
@@ -84,7 +84,7 @@ class reader:
                 fl.read(2) # padding
                 nfacets += 1
             
-            except struct.error, e:
+            except struct.error as e:
                 break
         
         if self.nfacets != nfacets:


### PR DESCRIPTION
reported at for the build:
https://github.com/conda-forge/staged-recipes/pull/8474
```
INFO:conda_build.build:Packaging opencamlib-2018.08-py36h770b8ee_0
compiling .pyc files...
  File "lib/python3.6/site-packages/STLTools.py", line 87
    except struct.error, e:
```