### PR TITLE
Removed add_subdirectory() calls from library .cmake files and moved …

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -241,6 +241,13 @@ set( OCL_INCLUDE_FILES
   ${OpenCamLib_SOURCE_DIR}/algo/tsp.hpp
   )
 
+# this branches into the dirs and compiles stuff there
+add_subdirectory( ${OpenCamLib_SOURCE_DIR}/cutters  )
+add_subdirectory( ${OpenCamLib_SOURCE_DIR}/geo  )
+add_subdirectory( ${OpenCamLib_SOURCE_DIR}/algo  ) 
+add_subdirectory( ${OpenCamLib_SOURCE_DIR}/dropcutter  ) 
+add_subdirectory( ${OpenCamLib_SOURCE_DIR}/common  ) 
+  
 if (BUILD_NODEJS_LIB)
   include(${CMAKE_CURRENT_SOURCE_DIR}/nodejslib/nodejslib.cmake)
 endif (BUILD_NODEJS_LIB)

--- a/src/cxxlib/cxxlib.cmake
+++ b/src/cxxlib/cxxlib.cmake
@@ -1,13 +1,6 @@
 find_package(Boost)
 include_directories(${Boost_INCLUDE_DIRS})
 
-# this branches into the dirs and compiles stuff there
-add_subdirectory( ${OpenCamLib_SOURCE_DIR}/cutters  )
-add_subdirectory( ${OpenCamLib_SOURCE_DIR}/geo  )
-add_subdirectory( ${OpenCamLib_SOURCE_DIR}/algo  ) 
-add_subdirectory( ${OpenCamLib_SOURCE_DIR}/dropcutter  ) 
-add_subdirectory( ${OpenCamLib_SOURCE_DIR}/common  ) 
-
 # include dirs
 include_directories( ${OpenCamLib_SOURCE_DIR}/cutters )
 include_directories( ${OpenCamLib_SOURCE_DIR}/geo )

--- a/src/emscriptenlib/emscriptenlib.cmake
+++ b/src/emscriptenlib/emscriptenlib.cmake
@@ -8,13 +8,6 @@ SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --bind -s MODULARIZE=1 -s SINGLE_FILE=1 
 find_package(Boost)
 include_directories(${Boost_INCLUDE_DIRS})
 
-# this branches into the dirs and compiles stuff there
-add_subdirectory( ${OpenCamLib_SOURCE_DIR}/cutters  )
-add_subdirectory( ${OpenCamLib_SOURCE_DIR}/geo  )
-add_subdirectory( ${OpenCamLib_SOURCE_DIR}/algo  ) 
-add_subdirectory( ${OpenCamLib_SOURCE_DIR}/dropcutter  ) 
-add_subdirectory( ${OpenCamLib_SOURCE_DIR}/common  ) 
-
 # include dirs
 include_directories( ${OpenCamLib_SOURCE_DIR}/cutters )
 include_directories( ${OpenCamLib_SOURCE_DIR}/geo )

--- a/src/nodejslib/nodejslib.cmake
+++ b/src/nodejslib/nodejslib.cmake
@@ -10,13 +10,6 @@ include_directories(${Boost_INCLUDE_DIRS})
 include_directories(${OpenCamLib_SOURCE_DIR}/../node_modules/node-addon-api)
 include_directories(${CMAKE_JS_INC})
 
-# this branches into the dirs and compiles stuff there
-add_subdirectory( ${OpenCamLib_SOURCE_DIR}/cutters  )
-add_subdirectory( ${OpenCamLib_SOURCE_DIR}/geo  )
-add_subdirectory( ${OpenCamLib_SOURCE_DIR}/algo  ) 
-add_subdirectory( ${OpenCamLib_SOURCE_DIR}/dropcutter  ) 
-add_subdirectory( ${OpenCamLib_SOURCE_DIR}/common  ) 
-
 # include dirs
 include_directories( ${OpenCamLib_SOURCE_DIR}/cutters )
 include_directories( ${OpenCamLib_SOURCE_DIR}/geo )

--- a/src/pythonlib/pythonlib.cmake
+++ b/src/pythonlib/pythonlib.cmake
@@ -91,13 +91,6 @@ message(STATUS "PYTHON_ARCH_PACKAGES = ${PYTHON_ARCH_PACKAGES}")
 include_directories(${Boost_INCLUDE_DIRS})
 include_directories(${PYTHON_INCLUDE_DIRS})
 
-# this branches into the dirs and compiles stuff there
-add_subdirectory( ${OpenCamLib_SOURCE_DIR}/cutters  )
-add_subdirectory( ${OpenCamLib_SOURCE_DIR}/geo  )
-add_subdirectory( ${OpenCamLib_SOURCE_DIR}/algo  ) 
-add_subdirectory( ${OpenCamLib_SOURCE_DIR}/dropcutter  ) 
-add_subdirectory( ${OpenCamLib_SOURCE_DIR}/common  ) 
-
 # include dirs
 include_directories( ${OpenCamLib_SOURCE_DIR}/cutters )
 include_directories( ${OpenCamLib_SOURCE_DIR}/geo )


### PR DESCRIPTION
…them to src/CmakeLists.txt

When building multiple libraries add_subdirectory() should be called once at the highest level. It's broken on Debian Unstable.