### PR TITLE
Fix most python examples, mostly by updating broken paths

### DIFF
--- a/examples/python/clsurf_1.py
+++ b/examples/python/clsurf_1.py
@@ -46,9 +46,9 @@ if __name__ == "__main__":
 
 # SURFACE
     
-    #stl = camvtk.STLSurf("../stl/Cylinder_1.stl")
-    #stl = camvtk.STLSurf("../stl/gnu_tux_mod.stl")
-    stl = camvtk.STLSurf("../stl/demo.stl")
+    #stl = camvtk.STLSurf("../../stl/Cylinder_1.stl")
+    #stl = camvtk.STLSurf("../../stl/gnu_tux_mod.stl")
+    stl = camvtk.STLSurf("../../stl/demo.stl")
     myscreen.addActor(stl)
     stl.SetWireframe()
     stl.SetColor((0.5,0.5,0.5))

--- a/examples/python/cutter_shapes.py
+++ b/examples/python/cutter_shapes.py
@@ -75,8 +75,8 @@ def getPathsX(s,cutter,sampling,x):
 if __name__ == "__main__":  
     print(ocl.version()) # revision()
     myscreen = camvtk.VTKScreen()
-    #stl = camvtk.STLSurf("../stl/demo.stl")
-    #stl = camvtk.STLSurf("../stl/30sphere.stl")
+    #stl = camvtk.STLSurf("../../stl/demo.stl")
+    #stl = camvtk.STLSurf("../../stl/30sphere.stl")
     #myscreen.addActor(stl)
     
     base=0.1

--- a/examples/python/drop-cutter/batchdropcutter_mtrush.py
+++ b/examples/python/drop-cutter/batchdropcutter_mtrush.py
@@ -10,9 +10,9 @@ if __name__ == "__main__":
     print(ocl.version())
     myscreen = camvtk.VTKScreen()
     
-    #stl = camvtk.STLSurf("../stl/gnu_tux_mod.stl")
-    stl = camvtk.STLSurf("../stl/mount_rush.stl") 
-    #stl = camvtk.STLSurf("../stl/pycam-textbox.stl") 
+    #stl = camvtk.STLSurf("../../../stl/gnu_tux_mod.stl")
+    stl = camvtk.STLSurf("../../../stl/mount_rush.stl")
+    #stl = camvtk.STLSurf("../../../stl/pycam-textbox.stl")
     myscreen.addActor(stl)
     stl.SetWireframe()
     stl.SetColor((0.5,0.5,0.5))

--- a/examples/python/drop-cutter/batchdropcutter_test_1.py
+++ b/examples/python/drop-cutter/batchdropcutter_test_1.py
@@ -11,8 +11,8 @@ if __name__ == "__main__":
     print(ocl.version()    )
     myscreen = camvtk.VTKScreen()
     
-    #stl = camvtk.STLSurf("../stl/gnu_tux_mod.stl")
-    stl = camvtk.STLSurf("../../stl/demo.stl")
+    #stl = camvtk.STLSurf("../../stl/gnu_tux_mod.stl")
+    stl = camvtk.STLSurf("../../../stl/demo.stl")
     myscreen.addActor(stl)
     stl.SetWireframe()
     stl.SetColor((0.5,0.5,0.5))

--- a/examples/python/drop-cutter/batchdropcutter_test_2.py
+++ b/examples/python/drop-cutter/batchdropcutter_test_2.py
@@ -12,8 +12,8 @@ if __name__ == "__main__":
     
     # read STL file from disk
     stl = camvtk.STLSurf("../../../stl/gnu_tux_mod.stl")
-    #stl = camvtk.STLSurf("../stl/beet_mm.stl")
-    #stl = camvtk.STLSurf("../stl/Blade.stl")
+    #stl = camvtk.STLSurf("../../../stl/beet_mm.stl")
+    #stl = camvtk.STLSurf("../../../stl/Blade.stl")
     myscreen.addActor(stl)
     stl.SetWireframe()
     stl.SetColor((0.5,0.5,0.5))

--- a/examples/python/drop-cutter/batchdropcutter_with_linefilter_test_1.py
+++ b/examples/python/drop-cutter/batchdropcutter_with_linefilter_test_1.py
@@ -9,9 +9,9 @@ import math
 if __name__ == "__main__": 
     print(ocl.version()    )
     myscreen = camvtk.VTKScreen()
-    #stl = camvtk.STLSurf("../stl/Cylinder_1.stl")
-    stl = camvtk.STLSurf("../../stl/gnu_tux_mod.stl")
-    #stl = camvtk.STLSurf("../stl/demo.stl")
+    #stl = camvtk.STLSurf("../../stl/Cylinder_1.stl")
+    stl = camvtk.STLSurf("../../../stl/gnu_tux_mod.stl")
+    #stl = camvtk.STLSurf("../../stl/demo.stl")
     myscreen.addActor(stl)
     stl.SetWireframe()
     stl.SetColor((0.5,0.5,0.5))

--- a/examples/python/drop-cutter/drop_cutter_tst_5.py
+++ b/examples/python/drop-cutter/drop_cutter_tst_5.py
@@ -8,7 +8,7 @@ import datetime
 if __name__ == "__main__":  
     print(ocl.version())
     myscreen = camvtk.VTKScreen()
-    stl = camvtk.STLSurf("../../stl/gnu_tux_mod.stl")
+    stl = camvtk.STLSurf("../../../stl/gnu_tux_mod.stl")
     
     myscreen.addActor(stl)
     stl.SetWireframe()

--- a/examples/python/edge_offset_tst_1.py
+++ b/examples/python/edge_offset_tst_1.py
@@ -78,7 +78,7 @@ if __name__ == "__main__":
     w2if = vtk.vtkWindowToImageFilter()
     w2if.SetInput(myscreen.renWin)
     lwr = vtk.vtkPNGWriter()
-    lwr.SetInput( w2if.GetOutput() )
+    lwr.SetInputConnection( w2if.GetOutputPort() )
 
         
     #for n in range(1,18):

--- a/examples/python/fiber/fiber_04_stl.py
+++ b/examples/python/fiber/fiber_04_stl.py
@@ -74,8 +74,8 @@ def xfiber(xvals,s,zh,myscreen):
 if __name__ == "__main__":  
     print(ocl.version() )
     myscreen = camvtk.VTKScreen()
-    #stl = camvtk.STLSurf("../stl/gnu_tux_mod.stl")
-    stl = camvtk.STLSurf("../../stl/demo.stl")
+    #stl = camvtk.STLSurf("../../stl/gnu_tux_mod.stl")
+    stl = camvtk.STLSurf("../../../stl/demo.stl")
     myscreen.addActor(stl)
     stl.SetWireframe()
     stl.SetColor((1,1,1))

--- a/examples/python/fiber/fiber_06_batch_stl.py
+++ b/examples/python/fiber/fiber_06_batch_stl.py
@@ -17,8 +17,8 @@ if __name__ == "__main__":
     print(ocl.version())
     
     myscreen = camvtk.VTKScreen()
-    #stl = camvtk.STLSurf("../stl/demo.stl")
-    stl = camvtk.STLSurf("../../stl/gnu_tux_mod.stl")
+    #stl = camvtk.STLSurf("../../stl/demo.stl")
+    stl = camvtk.STLSurf("../../../stl/gnu_tux_mod.stl")
     myscreen.addActor(stl)
     #stl.SetWireframe()
     stl.SetSurface()

--- a/examples/python/fiber/fiber_08_stl_weave.py
+++ b/examples/python/fiber/fiber_08_stl_weave.py
@@ -18,8 +18,8 @@ def generateRange(zmin,zmax,zNmax):
 if __name__ == "__main__":  
     print(ocl.version())
     myscreen = camvtk.VTKScreen()
-    #stl = camvtk.STLSurf("../stl/demo.stl")
-    stl = camvtk.STLSurf("../../stl/gnu_tux_mod.stl")
+    #stl = camvtk.STLSurf("../../stl/demo.stl")
+    stl = camvtk.STLSurf("../../../stl/gnu_tux_mod.stl")
     myscreen.addActor(stl)
     stl.SetWireframe()
     #stl.SetSurface()

--- a/examples/python/fiber/fiber_10_offsets.py
+++ b/examples/python/fiber/fiber_10_offsets.py
@@ -70,8 +70,8 @@ def waterline(cutter, s, zh, tol = 0.1 ):
 if __name__ == "__main__":  
     print(ocl.version())
     myscreen = camvtk.VTKScreen()
-    #stl = camvtk.STLSurf("../stl/demo.stl")
-    stl = camvtk.STLSurf("../../stl/gnu_tux_mod.stl")
+    #stl = camvtk.STLSurf("../../stl/demo.stl")
+    stl = camvtk.STLSurf("../../../stl/gnu_tux_mod.stl")
     myscreen.addActor(stl)
     stl.SetWireframe()
     #stl.SetSurface()

--- a/examples/python/fiber/fiber_16_weave2_RAMusage.py
+++ b/examples/python/fiber/fiber_16_weave2_RAMusage.py
@@ -17,8 +17,8 @@ def drawVertices(myscreen, weave, vertexType, vertexRadius, vertexColor):
         myscreen.addActor( camvtk.Sphere(center=(p.x,p.y,p.z), radius=vertexRadius, color=vertexColor ) )
 
 def getWeaveRAM(Nmax,weave2_flag):
-    #stl = camvtk.STLSurf("../stl/demo.stl")
-    stl = camvtk.STLSurf("../../stl/gnu_tux_mod.stl")
+    #stl = camvtk.STLSurf("../../stl/demo.stl")
+    stl = camvtk.STLSurf("../../../stl/gnu_tux_mod.stl")
     polydata = stl.src.GetOutput()
     s = ocl.STLSurf()
     camvtk.vtkPolyData2OCLSTL(polydata, s)

--- a/examples/python/fiber/fiber_16_weave2_STL.py
+++ b/examples/python/fiber/fiber_16_weave2_STL.py
@@ -17,8 +17,8 @@ def drawVertices(myscreen, weave, vertexType, vertexRadius, vertexColor):
 if __name__ == "__main__":  
     print(ocl.version())
     myscreen = camvtk.VTKScreen()
-    #stl = camvtk.STLSurf("../stl/demo.stl")
-    stl = camvtk.STLSurf("../../stl/gnu_tux_mod.stl")
+    #stl = camvtk.STLSurf("../../stl/demo.stl")
+    stl = camvtk.STLSurf("../../../stl/gnu_tux_mod.stl")
     myscreen.addActor(stl)
     stl.SetWireframe()
     #stl.SetSurface()

--- a/examples/python/issues/issue08_bug2010-04-02.py
+++ b/examples/python/issues/issue08_bug2010-04-02.py
@@ -8,7 +8,7 @@ if __name__ == "__main__":
     path = ocl.Path()
     path.append(ocl.Line(ocl.Point(-6.51, 0, 0), ocl.Point(6.51, 1.2, 0)))
     s=ocl.STLSurf()
-    ocl.STLReader("../../stl/sphere2.stl",s)
+    ocl.STLReader("../../../stl/sphere2.stl",s)
     pdc = ocl.PathDropCutter()
     pdc.setSTL(s)
     pdc.setCutter(cutter)

--- a/examples/python/kdtree_debug_1.py
+++ b/examples/python/kdtree_debug_1.py
@@ -33,7 +33,7 @@ def main():
     w2if = vtk.vtkWindowToImageFilter()
     w2if.SetInput(myscreen.renWin)
     lwr = vtk.vtkPNGWriter()
-    lwr.SetInput( w2if.GetOutput() )
+    lwr.SetInputConnection( w2if.GetOutputPort() )
   
     epos = cam.Epos()
     epos.setS(0,1)

--- a/examples/python/kdtree_debug_3.py
+++ b/examples/python/kdtree_debug_3.py
@@ -172,9 +172,9 @@ def main():
     myscreen.addActor( t2)
         
     w2if = vtk.vtkWindowToImageFilter()
-    w2if.SetInput(myscreen.renWin)
+    w2if.SetInputConnection(myscreen.renWin)
     lwr = vtk.vtkPNGWriter()
-    lwr.SetInput( w2if.GetOutput() )
+    lwr.SetInputConnection( w2if.GetOutputPort() )
   
     epos = cam.Epos()
     epos.setS(0,1)

--- a/examples/python/kdtree_movie1.py
+++ b/examples/python/kdtree_movie1.py
@@ -20,7 +20,8 @@ if __name__ == "__main__":
     camvtk.vtkPolyData2OCLSTL(polydata, s)
     print("STLSurf with ", s.size(), " triangles")
     cutterDiameter=0.6
-    cutter = cam.CylCutter(cutterDiameter)
+    cutterLength=5
+    cutter = cam.CylCutter(cutterDiameter, cutterLength)
     #print cutter.str()
     #print cc.type
     minx=-20
@@ -28,7 +29,7 @@ if __name__ == "__main__":
     maxx=20
     
     miny=-20
-    dy=01
+    dy=1
     maxy=20
     z=-0.2
     

--- a/examples/python/kdtree_movie2.py
+++ b/examples/python/kdtree_movie2.py
@@ -23,7 +23,8 @@ if __name__ == "__main__":
     camvtk.vtkPolyData2OCLSTL(polydata, s)
     print("STLSurf with ", s.size(), " triangles")
     cutterDiameter=1
-    cutter = cam.CylCutter(cutterDiameter)
+    cutterLength=5
+    cutter = cam.CylCutter(cutterDiameter, 6)
     #print cutter.str()
     #print cc.type
     minx=0

--- a/examples/python/lineclfilter_test.py
+++ b/examples/python/lineclfilter_test.py
@@ -1,6 +1,6 @@
 import ocl
 
-print ocl.version()
+print(ocl.version())
 
 p0 = ocl.CLPoint(0,0,0)
 p1 = ocl.CLPoint(1,2,3)

--- a/examples/python/ocl_bounding-box.py
+++ b/examples/python/ocl_bounding-box.py
@@ -33,9 +33,9 @@ if __name__ == "__main__":
     
     myscreen = camvtk.VTKScreen()
     
-    stl = camvtk.STLSurf("../stl/gnu_tux_mod.stl")
-    #stl = camvtk.STLSurf("../stl/beet_mm.stl")
-    #stl = camvtk.STLSurf("../stl/Blade.stl")
+    stl = camvtk.STLSurf("../../stl/gnu_tux_mod.stl")
+    #stl = camvtk.STLSurf("../../stl/beet_mm.stl")
+    #stl = camvtk.STLSurf("../../stl/Blade.stl")
     myscreen.addActor(stl)
     stl.SetWireframe()
     stl.SetColor((0.5,0.5,0.5))
@@ -67,4 +67,3 @@ if __name__ == "__main__":
     
     myscreen.render()
     myscreen.iren.Start()
-    raw_input("Press Enter to terminate") 

--- a/examples/python/ocl_clpoint.py
+++ b/examples/python/ocl_clpoint.py
@@ -3,14 +3,14 @@ import ocl
 # print(ocl.version())
 
 p = ocl.Point(1,2,3)
-print p
+print(p)
 cc = ocl.CCPoint(4,5,6)
-print cc
+print(cc)
 cl = ocl.CLPoint()
-print cl
+print(cl)
 cl2 = ocl.CLPoint(7,8,9)
-print cl2
+print(cl2)
 cl3 = ocl.CLPoint(10,11,12,cc)
-print cl3
+print(cl3)
 cc.x=77
-print cl3
+print(cl3)

--- a/examples/python/ocl_docstring_test.py
+++ b/examples/python/ocl_docstring_test.py
@@ -3,6 +3,6 @@ import ocl
 
 #
 c=ocl.BallCutter(1,2)
-print c.__doc__
-print ocl.version()
+print(c.__doc__)
+print(ocl.version())
 help(ocl.BallCutter(4,5))

--- a/examples/python/ocl_offsetCutter_1.py
+++ b/examples/python/ocl_offsetCutter_1.py
@@ -1,33 +1,33 @@
 import ocl
 import math
 
-print ocl.version()
+print(ocl.version())
 
 # cylinder
 c = ocl.CylCutter(2.345, 5)
 d = c.offsetCutter(0.1)
-print c
-print "offset: ",d
+print(c)
+print("offset: ",d)
 print
 
 # ball
 c = ocl.BallCutter(2.345, 6)
 d = c.offsetCutter(0.1)
-print c
-print "offset: ",d
+print(c)
+print("offset: ",d)
 print
 
 # bull
 c = ocl.BullCutter(2.345, 0.123, 6)
 d = c.offsetCutter(0.1)
-print c
-print "offset: ",d
+print(c)
+print("offset: ",d)
 print
 
 # cone
-c = ocl.ConeCutter(2.345, math.pi/6)
+c = ocl.ConeCutter(2.345, math.pi/6, 5)
 d = c.offsetCutter(0.1)
-print c
-print "offset: ",d
+print(c)
+print("offset: ",d)
 
 # TODO: add compound-cutters here below.

--- a/examples/python/ocl_stl2ocl_tst.py
+++ b/examples/python/ocl_stl2ocl_tst.py
@@ -6,7 +6,7 @@ if __name__ == "__main__":
     s= ocl.STLSurf()
     print(s)
     myscreen = camvtk.VTKScreen()
-    stl = camvtk.STLSurf("../stl/demo.stl")
+    stl = camvtk.STLSurf("../../stl/demo.stl")
     print("STL surface read")
     myscreen.addActor(stl)
     stl.SetWireframe()

--- a/examples/python/ocl_stlsurf_polydata.py
+++ b/examples/python/ocl_stlsurf_polydata.py
@@ -22,7 +22,7 @@ if __name__ == "__main__":
     
     myscreen = camvtk.VTKScreen()
     print("screen created")
-    stl = camvtk.STLSurf("../stl/sphere.stl")
+    stl = camvtk.STLSurf("../../stl/sphere.stl")
     print("STL surface read")
     myscreen.addActor(stl)
     

--- a/examples/python/offsetCutter_test_2.py
+++ b/examples/python/offsetCutter_test_2.py
@@ -107,7 +107,7 @@ if __name__ == "__main__":
     w2if = vtk.vtkWindowToImageFilter()
     w2if.SetInput(myscreen.renWin)
     lwr = vtk.vtkPNGWriter()
-    lwr.SetInput( w2if.GetOutput() )
+    lwr.SetInputConnection( w2if.GetOutputPort() )
     t = camvtk.Text()
     t.SetPos( (myscreen.width-350, myscreen.height-30) )
     myscreen.addActor(t)

--- a/examples/python/old/cutsim_test_tux_1.py
+++ b/examples/python/old/cutsim_test_tux_1.py
@@ -30,7 +30,7 @@ def main(filename="frame/f.png"):
     print("cutter length=", c.length)
     
     # generate CL-points
-    stl = camvtk.STLSurf("../stl/gnu_tux_mod.stl")
+    stl = camvtk.STLSurf("../../stl/gnu_tux_mod.stl")
     polydata = stl.src.GetOutput()
     s = ocl.STLSurf()
     camvtk.vtkPolyData2OCLSTL(polydata, s)

--- a/examples/python/path_example_1.py
+++ b/examples/python/path_example_1.py
@@ -3,7 +3,7 @@ import ocl
 
 # This example shows how to aggregate lines and arcs into path objects and then
 # how to retrieve such data.
-print ocl.version()
+print(ocl.version())
 
 paths = []
 
@@ -35,7 +35,7 @@ paths.append(path_id_3)
 for path in paths:
 	# Retrieve a list of type/span pairs.  The type indicates whether it's a line or an arc
 	spans = path.getTypeSpanPairs()
-	print '\n\nSpan'
+	print('\n\nSpan')
 
 	for span in spans:
 		span_type = span[0]
@@ -43,9 +43,9 @@ for path in paths:
 
 		if (span_type == ocl.ArcSpanType):
 			arc = span_element
-			print 'Arc(start=' + str(arc.p1) + ', centre=' + str(arc.c) + ' end=' + str(arc.p2) + ')'
+			print('Arc(start=' + str(arc.p1) + ', centre=' + str(arc.c) + ' end=' + str(arc.p2) + ')')
 
 		if (span_type == ocl.LineSpanType):
 			line = span_element
-			print 'Line(start=' + str(line.p1) + ', end=' + str(line.p2) + ')'
+			print('Line(start=' + str(line.p1) + ', end=' + str(line.p2) + ')')
 

--- a/examples/python/pathdropcutter_test_1.py
+++ b/examples/python/pathdropcutter_test_1.py
@@ -8,11 +8,12 @@ if __name__ == "__main__":
     print(ocl.version())
     
     myscreen = camvtk.VTKScreen()    
-    stl = camvtk.STLSurf("../stl/gnu_tux_mod.stl")
+    stl = camvtk.STLSurf("../../../stl/gnu_tux_mod.stl")
     print("STL surface read")
     myscreen.addActor(stl)
     stl.SetWireframe()    
     polydata = stl.src.GetOutput()
+    print(dir(polydata))
     s= ocl.STLSurf()
     camvtk.vtkPolyData2OCLSTL(polydata, s)
     print("STLSurf with ", s.size(), " triangles")

--- a/examples/python/pathdropcutter_test_2.py
+++ b/examples/python/pathdropcutter_test_2.py
@@ -8,8 +8,8 @@ if __name__ == "__main__":
     print(ocl.version())
     
     myscreen = camvtk.VTKScreen()    
-    stl = camvtk.STLSurf("../stl/demo.stl")
-    #stl = camvtk.STLSurf("../stl/pycam-textbox.stl") 
+    stl = camvtk.STLSurf("../../stl/demo.stl")
+    #stl = camvtk.STLSurf("../../stl/pycam-textbox.stl") 
     print("STL surface read")
     myscreen.addActor(stl)
     stl.SetWireframe()    

--- a/examples/python/pycam_bench.py
+++ b/examples/python/pycam_bench.py
@@ -43,8 +43,8 @@ if __name__ == "__main__":
     print(ocl.version())
     
     myscreen = camvtk.VTKScreen()    
-    #stl = camvtk.STLSurf("../stl/demo.stl")
-    stl = camvtk.STLSurf("../stl/pycam-textbox.stl") 
+    #stl = camvtk.STLSurf("../../../stl/demo.stl")
+    stl = camvtk.STLSurf("../../../stl/pycam-textbox.stl") 
     print("STL surface read")
     myscreen.addActor(stl)
     stl.SetWireframe()    

--- a/examples/python/toolpath_examples/parallel_finish_zig.py
+++ b/examples/python/toolpath_examples/parallel_finish_zig.py
@@ -178,7 +178,7 @@ def vtk_visualize_parallel_finish_zig(stlfile, toolpaths):
 
 
 if __name__ == "__main__":     
-    stlfile = "../../stl/gnu_tux_mod.stl"
+    stlfile = "../../../stl/gnu_tux_mod.stl"
     surface = STLSurfaceSource(stlfile)
     
     

--- a/examples/python/toolpath_examples/waterline_simple.py
+++ b/examples/python/toolpath_examples/waterline_simple.py
@@ -76,7 +76,7 @@ def drawLoops(myscreen,loops,loopColor):
         nloop = nloop+1
 
 if __name__ == "__main__":     
-    stlfile = "../../stl/gnu_tux_mod.stl"
+    stlfile = "../../../stl/gnu_tux_mod.stl"
     surface = STLSurfaceSource(stlfile)
     
 

--- a/examples/python/waterline/waterline_1_tux.py
+++ b/examples/python/waterline/waterline_1_tux.py
@@ -8,8 +8,8 @@ import math
 if __name__ == "__main__":  
     print(ocl.version())
     myscreen = camvtk.VTKScreen()
-    #stl = camvtk.STLSurf("../../stl/demo.stl")
-    stl = camvtk.STLSurf("../../stl/gnu_tux_mod.stl")
+    #stl = camvtk.STLSurf("../../../stl/demo.stl")
+    stl = camvtk.STLSurf("../../../stl/gnu_tux_mod.stl")
     myscreen.addActor(stl)
     stl.SetWireframe() # render tux as wireframe
     #stl.SetSurface() # render tux as surface

--- a/examples/python/waterline/waterline_2_tux_adapt.py
+++ b/examples/python/waterline/waterline_2_tux_adapt.py
@@ -31,9 +31,9 @@ def drawLoops(myscreen, loops, loopcolor):
 if __name__ == "__main__":  
     print(ocl.version())
     myscreen = camvtk.VTKScreen()
-    #stl = camvtk.STLSurf("../../stl/demo.stl")
-    stl = camvtk.STLSurf("../../stl/gnu_tux_mod.stl")
-    #stl = camvtk.STLSurf("../../stl/waterline1.stl")
+    #stl = camvtk.STLSurf("../../../stl/demo.stl")
+    stl = camvtk.STLSurf("../../../stl/gnu_tux_mod.stl")
+    #stl = camvtk.STLSurf("../../../stl/waterline1.stl")
     myscreen.addActor(stl)
     stl.SetWireframe() # render tux as wireframe
     #stl.SetSurface() # render tux as surface

--- a/examples/python/waterline/waterline_5_30ball.py
+++ b/examples/python/waterline/waterline_5_30ball.py
@@ -41,9 +41,9 @@ def getWaterline(s, cutter, zh):
 if __name__ == "__main__":  
     print(ocl.version())
     myscreen = camvtk.VTKScreen()
-    #stl = camvtk.STLSurf("../../stl/demo.stl")
-    #stl = camvtk.STLSurf("../../stl/30sphere.stl")
-    stl = camvtk.STLSurf("../../stl/failedinpycam.stl")
+    #stl = camvtk.STLSurf("../../../stl/demo.stl")
+    #stl = camvtk.STLSurf("../../../stl/30sphere.stl")
+    stl = camvtk.STLSurf("../../../stl/failedinpycam.stl")
     myscreen.addActor(stl)
     stl.SetWireframe() # render tux as wireframe
     #stl.SetSurface() # render tux as surface

--- a/examples/python/waterline/waterline_6_weave2.py
+++ b/examples/python/waterline/waterline_6_weave2.py
@@ -36,7 +36,7 @@ if __name__ == "__main__":
     s.addTriangle(t) # a one-triangle STLSurf
     
     # alternatively, run on the tux model
-    stl = camvtk.STLSurf("../../stl/gnu_tux_mod.stl")
+    stl = camvtk.STLSurf("../../../stl/gnu_tux_mod.stl")
     #myscreen.addActor(stl)
     #stl.SetWireframe() # render tux as wireframe
     #stl.SetSurface() # render tux as surface

--- a/examples/python/waterline/waterline_7_cavity.py
+++ b/examples/python/waterline/waterline_7_cavity.py
@@ -35,12 +35,12 @@ def drawLoops(myscreen, loops, loopcolor):
 if __name__ == "__main__":  
     print(ocl.version())
     myscreen = camvtk.VTKScreen()
-    #stl = camvtk.STLSurf("../../stl/demo.stl")
-    #stl = camvtk.STLSurf("../../stl/gnu_tux_mod.stl")
-    #stl = camvtk.STLSurf("../../stl/porche.stl")
-    #stl = camvtk.STLSurf("../../stl/ktoolcav.stl")
-    #stl = camvtk.STLSurf("../../stl/ktoolcor.stl")
-    stl = camvtk.STLSurf("../../stl/sphere_cutout.stl")
+    #stl = camvtk.STLSurf("../../../stl/demo.stl")
+    #stl = camvtk.STLSurf("../../../stl/gnu_tux_mod.stl")
+    #stl = camvtk.STLSurf("../../../stl/porche.stl")
+    #stl = camvtk.STLSurf("../../../stl/ktoolcav.stl")
+    #stl = camvtk.STLSurf("../../../stl/ktoolcor.stl")
+    stl = camvtk.STLSurf("../../../stl/sphere_cutout.stl")
     #myscreen.addActor(stl)
     #stl.SetWireframe() # render tux as wireframe
     #stl.SetSurface() # render tux as surface

--- a/examples/python/waterline/waterline_8_tux_adaptive.py
+++ b/examples/python/waterline/waterline_8_tux_adaptive.py
@@ -43,8 +43,8 @@ def getLoops(wl,zh,diam):
 if __name__ == "__main__":  
     print(ocl.version())
     myscreen = camvtk.VTKScreen()
-    #stl = camvtk.STLSurf("../../stl/demo.stl")
-    stl = camvtk.STLSurf("../../stl/gnu_tux_mod.stl")
+    #stl = camvtk.STLSurf("../../../stl/demo.stl")
+    stl = camvtk.STLSurf("../../../stl/gnu_tux_mod.stl")
     myscreen.addActor(stl)
     #stl.SetWireframe() # render tux as wireframe
     stl.SetSurface() # render tux as surface


### PR DESCRIPTION
- There are some examples that use functions that don't exist anymore `cam.Epos()`, they should probably be removed
- in vtk, `SetInput` got removed, now, `SetInputConnection` should be used, I am not sure how to get an OutputConnection for `w2if.SetInput(myscreen.renWin)`, this breaks a couple of examples