### PR TITLE
Enable LTO when available

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -90,6 +90,12 @@ if(UNIX)
   endif()
 endif()
 
+include(CheckIPOSupported)
+check_ipo_supported(RESULT got_ipo_support)
+if(got_ipo_support)
+  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+endif()
+
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 set(Boost_DEBUG ON CACHE BOOL "boost-debug")

--- a/src/cxxlib/cxxlib.cmake
+++ b/src/cxxlib/cxxlib.cmake
@@ -33,6 +33,17 @@ target_include_directories(ocl
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
+# disable /GL and enable /LTCG (see https://github.com/luxonis/depthai-core/issues/334)
+if(WIN32 AND MSVC) # AND CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS
+  get_target_property(_INTER_OPT ocl INTERPROCEDURAL_OPTIMIZATION)
+  if(_INTER_OPT)
+    message(STATUS "Workaround MSVC dll exports with INTERPROCEDURAL_OPTIMIZATION")
+    set_target_properties(ocl PROPERTIES INTERPROCEDURAL_OPTIMIZATION OFF)
+    target_link_options(ocl PRIVATE /LTCG)
+  endif()
+  unset(_INTER_OPT)
+endif()
+
 # link with Boost and optionally with OpenMP
 target_link_libraries(ocl PUBLIC Boost::boost)
 if(USE_OPENMP)


### PR DESCRIPTION
This speeds up OCL a lot, almost 2x as fast over here, this is mostly because of operators on the Point class, which are not optimized without LTO.