### PR TITLE
Use proper python module destination

### DIFF
--- a/src/pythonlib/pythonlib.cmake
+++ b/src/pythonlib/pythonlib.cmake
@@ -3,6 +3,7 @@ if(Python3_FOUND)
   message(STATUS "Found Python: " ${Python3_VERSION})
   message(STATUS "Python libraries: " ${Python3_LIBRARIES})
   message(STATUS "Python executable: " ${Python3_EXECUTABLE})
+  message(STATUS "Python (arch-dependant) module destination: " ${Python3_SITEARCH})
 endif()
 find_package(Boost COMPONENTS python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR} REQUIRED)
 
@@ -41,17 +42,11 @@ if(USE_OPENMP)
   target_link_libraries(ocl PRIVATE OpenMP::OpenMP_CXX)
 endif()
 
-execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} -c "import site; print(site.getsitepackages()[-2])"
-    OUTPUT_VARIABLE PYTHON_ARCH_PACKAGES
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-
-install(TARGETS ocl LIBRARY DESTINATION "${PYTHON_ARCH_PACKAGES}/opencamlib")
+install(TARGETS ocl LIBRARY DESTINATION "${Python3_SITEARCH}/opencamlib")
 if(NOT SKBUILD)
   install(
     DIRECTORY pythonlib/opencamlib/
-    DESTINATION "${PYTHON_ARCH_PACKAGES}/opencamlib"
+    DESTINATION "${Python3_SITEARCH}/opencamlib"
   )
 endif()
 


### PR DESCRIPTION
Since the maintainer of the AUR package (https://aur.archlinux.org/packages/opencamlib-git) appears to have difficulties keeping up with patching the python module install path (my install was broken *again*), I thought it should actually be fixed upstream.
I also noted the issue of the Debian package maintainer (#157 ) and this should improve the situation there as well.

The "FindPython3" CMake module already provides variables containing the paths for installing modules into (https://cmake.org/cmake/help/latest/module/FindPython3.html, `Python3_SITELIB` and `Python3_SITEARCH`), so why not use these directly? This way it should be a lot more portable and not require the execute_process.

Note: Since `site.getsitepackages()` only contains one element on my system, the index `[-2]` is out of bounds resulting in an exception. This caused the python module being installed to `/opencamlib`, which, I think, is even worse than `/usr/lib/opencamlib`, as it was in the version before :smiling_face_with_tear: 