### PR TITLE
Fix typos

### DIFF
--- a/src/common/halfedgediagram.hpp
+++ b/src/common/halfedgediagram.hpp
@@ -194,7 +194,7 @@ VertexVector vertices()  {
     return vv;
 }
 
-/// return all vertices adjecent to given vertex
+/// return all vertices adjacent to given vertex
 VertexVector adjacent_vertices(  Vertex v) {
     VertexVector vv;
     BOOST_FOREACH( Edge edge, out_edges( v ) ) {

--- a/src/geo/triangle.hpp
+++ b/src/geo/triangle.hpp
@@ -45,7 +45,7 @@ class Triangle {
         Triangle(Point p1, Point p2, Point p3);   
         
         /// return true if Triangle is sliced by a z-plane at z=zcut
-        /// modify p1 and p2 so that they are intesections of the triangle edges
+        /// modify p1 and p2 so that they are intersections of the triangle edges
         /// and the plane. These vertices are used by CylCutter::edgePush()
         bool zslice_verts(Point& p1, Point& p2, double zcut) const;
         


### PR DESCRIPTION
Found via `codespell -q 3 -L childs,eachother,ede,keypair,re-using,whe,wih,wil,zar`